### PR TITLE
Improve list item styling when text wraps to a second line

### DIFF
--- a/assets/stylesheets/_lists.scss
+++ b/assets/stylesheets/_lists.scss
@@ -4,7 +4,15 @@ ul, ol {
     padding-left: 1rem;
 
     > li {
+        position: relative;
+        margin-bottom: $spacer--1;
+
         &::before {
+            position: absolute;
+            display: block;
+            top: 0em;
+            left: -1em;
+            content: 'x';
             padding-right: $spacer--1;
         }
     }


### PR DESCRIPTION
A style already existed for the bullet on UL lists, this fixes the wrapping and adds space below list items, to change the display from this:
<img width="276" alt="screen shot 2017-10-17 at 11 00 38 am" src="https://user-images.githubusercontent.com/4950114/31675931-aa7332d8-b32b-11e7-9cc3-adc83d031b88.png">

to this:
<img width="274" alt="screen shot 2017-10-17 at 11 03 43 am" src="https://user-images.githubusercontent.com/4950114/31675958-c174acbe-b32b-11e7-92f8-b568e9809ff6.png">

This is based on the hover state in the designs attached to MAR-5739:
https://wpengine.atlassian.net/browse/MAR-5739