### PR TITLE
Fix select menu background

### DIFF
--- a/assets/stylesheets/_forms.scss
+++ b/assets/stylesheets/_forms.scss
@@ -51,8 +51,8 @@ select:not([multiple]) {
   border: 1px solid $color--polar-10;
   -webkit-appearance: none;
   border-radius: 0;
-  background: $color--white;
-  background: url(data:image/svg+xml,%3Csvg%20version%3D%221.1%22%20id%3D%22Layer_1%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%207.5%204.8%22%20enable-background%3D%22new%200%200%207.5%204.8%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cg%3E%0A%09%3Cpolygon%20fill%3D%22%236B757B%22%20points%3D%223.8%2C4.8%200%2C1.1%201.1%2C0%203.8%2C2.7%206.5%2C0%207.6%2C1.1%20%09%22/%3E%0A%3C/g%3E%0A%3C/svg%3E%0A);
+  background-color: $color--white;
+  background-image: url(data:image/svg+xml,%3Csvg%20version%3D%221.1%22%20id%3D%22Layer_1%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%207.5%204.8%22%20enable-background%3D%22new%200%200%207.5%204.8%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cg%3E%0A%09%3Cpolygon%20fill%3D%22%236B757B%22%20points%3D%223.8%2C4.8%200%2C1.1%201.1%2C0%203.8%2C2.7%206.5%2C0%207.6%2C1.1%20%09%22/%3E%0A%3C/g%3E%0A%3C/svg%3E%0A);
   background-repeat: no-repeat;
   background-position: calc(100% - 16px) 50%;
   background-size: 16px;


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
n/a

## Description
The `<select>` menu styling was setting the `background` for both the color and the background-image, so the image was overriding the color instead of adding to it. 

## Impacted Areas in Application
Select menus on non-white backgrounds. 

## Random GIF
Include one random GIF to "pay" your reviewers in humor.

![Thanks for reviewing my code!](https://media.giphy.com/media/lgRNj0m1oORfW/giphy-tumblr.gif)
