### PR TITLE
feature(_lists.scss): add in a class that provide numeric to alpha su…

### DIFF
--- a/assets/stylesheets/_lists.scss
+++ b/assets/stylesheets/_lists.scss
@@ -45,3 +45,31 @@ ol {
     }
   }
 }
+
+.list-number-alpha {
+	margin-bottom: 0;
+	counter-reset: item;
+	& li {
+		margin-left: 20px;
+		padding-left: 20px;
+		display: block;
+		position: relative;
+		&:before {
+			content: counters(item, ".", decimal) ".";
+			counter-increment: item;
+			position: absolute;
+			margin-right: 100%;
+			right: 20px;
+		}
+	}
+
+	& ol {
+		counter-reset: subitem;
+		& li {
+			&:before {
+				content: counter(subitem, lower-alpha) ".";
+				counter-increment: subitem;
+			}
+		}
+	}
+}

--- a/assets/stylesheets/_lists.scss
+++ b/assets/stylesheets/_lists.scss
@@ -46,60 +46,29 @@ ol {
   }
 }
 
-.list-number-alpha {
-	margin-bottom: 0;
-	counter-reset: item;
 ol.list-number-alpha {
-	margin-bottom: 0;
-	counter-reset: item;
-
-	li {
-		margin-left: 20px;
-		padding-left: 20px;
-		display: block;
-		position: relative;
-
-		&:before {
-			content: counters(item, ".", decimal) ".";
-			counter-increment: item;
-			position: absolute;
-			margin-right: 100%;
-			right: 20px;
-		}
-	}
-
-	ol {
-		counter-reset: subitem;
-
-		li {
-			&:before {
-				content: counter(subitem, lower-alpha) ".";
-				counter-increment: subitem;
-			}
-		}
-	}
-}
-
-		margin-left: 20px;
-		padding-left: 20px;
-		display: block;
-		position: relative;
-		&:before {
-			content: counters(item, ".", decimal) ".";
-			counter-increment: item;
-			position: absolute;
-			margin-right: 100%;
-			right: 20px;
-		}
-	}
-
-	& ol {
-		counter-reset: subitem;
-		& li {
-			&:before {
-				content: counter(subitem, lower-alpha) ".";
-				counter-increment: subitem;
-			}
-		}
-	}
+  margin-bottom: 0;
+  counter-reset: item;
+  li {
+    margin-left: 20px;
+    padding-left: 20px;
+    display: block;
+    position: relative;
+    &:before {
+      content: counters(item, ".", decimal) ".";
+      counter-increment: item;
+      position: absolute;
+      margin-right: 100%;
+      right: 20px;
+    }
+  }
+  ol {
+    counter-reset: subitem;
+    li {
+      &:before {
+        content: counter(subitem, lower-alpha) ".";
+        counter-increment: subitem;
+      }
+    }
+  }
 }

--- a/assets/stylesheets/_lists.scss
+++ b/assets/stylesheets/_lists.scss
@@ -49,7 +49,37 @@ ol {
 .list-number-alpha {
 	margin-bottom: 0;
 	counter-reset: item;
-	& li {
+ol.list-number-alpha {
+	margin-bottom: 0;
+	counter-reset: item;
+
+	li {
+		margin-left: 20px;
+		padding-left: 20px;
+		display: block;
+		position: relative;
+
+		&:before {
+			content: counters(item, ".", decimal) ".";
+			counter-increment: item;
+			position: absolute;
+			margin-right: 100%;
+			right: 20px;
+		}
+	}
+
+	ol {
+		counter-reset: subitem;
+
+		li {
+			&:before {
+				content: counter(subitem, lower-alpha) ".";
+				counter-increment: subitem;
+			}
+		}
+	}
+}
+
 		margin-left: 20px;
 		padding-left: 20px;
 		display: block;


### PR DESCRIPTION
…b list items.

## Status
**READY**

## JIRA Ticket
[A link to the relevant JIRA ticket](https://wpengine.atlassian.net/browse/WEB-1603)

## Description
Provides a class that lists ordered list items numerically then subclasses become either decimal pointed or alphanumeric if it's a sub-ordered list.
sub ol
1. 
   a.
   b.
   c. 

## Impacted Areas in Application
List general components of the site that this PR will affect:

* Nothing until applied, but this will go on the legal pages.

## Deploy Notes

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

1. Create an ordered with the class.
      <ol class="list-number-alpha">
		<li><strong>Agreement</strong>
			<ol>
				<li>Some stuff</li>
				<li>some stuff</li>
				<li>some stuff</li>
			</ol>
                </li>
      </ol>
2. Bob's your uncle, that's it. 
3. Ignore the roman numerals being applied to this list, though. Git's doing it on it's own.
4. I included the updated legal pages html structure that will fit this class. In order to make it easier on the designer to build these pages. https://wpengine.atlassian.net/browse/WEB-1546
## Random GIF
Include one random GIF to "pay" your reviewers in humor.

![Thanks for reviewing my code!](https://media.giphy.com/media/26ufnwz3wDUli7GU0/giphy-downsized.gif)
