### PR TITLE
fix(_forms.scss): refactor checked and radio boxes code. Switch the p…

### DIFF
--- a/assets/stylesheets/_forms.scss
+++ b/assets/stylesheets/_forms.scss
@@ -95,36 +95,35 @@ input[type="checkbox"],
 input[type="radio"] {
   position: relative;
   display: inline-block;
+  visibility: hidden;
+  width: $font--size-large;
+  height: $font--size-large;
   margin: 0 $spacer--1;
   font-weight: $font--weight;
   font-size: $font--size-bump;
-  visibility: hidden;
-  width: 24px;
-  height: 24px;
   vertical-align: middle;
 
   &::before {
     display: inline-block;
     position: absolute;
     content: "";
-    height: 100%;
+    visibility: visible;
     width: 100%;
-    border: 1px solid $color--polar-10;
-    left: $spacer--1;
+    height: 100%;
     top: 0;
     left: 0;
-    visibility: visible;
+    border: 1px solid $color--polar-10;
   }
 
   &::after {
     display: inline-block;
     position: absolute;
     content: none;
+    visibility: visible;
     height: 60%;
     width: 60%;
     top: 20%;
     left: 20%;
-    visibility: visible;
     background-color: $color--tiffany;
     @extend %background--tiffoam;
   }
@@ -132,7 +131,7 @@ input[type="radio"] {
   + label {
     display: inline-block;
     width: auto;
-    line-height: 24px;
+    line-height: $font--size-large;
     vertical-align: middle;
   }
 
@@ -141,7 +140,7 @@ input[type="radio"] {
   }
 
   &:focus::before {
-    outline: $color--polar-40 auto 3px;
+    outline: $color--polar-40 auto $spacer--border;
   }
 }
 

--- a/assets/stylesheets/_forms.scss
+++ b/assets/stylesheets/_forms.scss
@@ -93,61 +93,64 @@ fieldset {
 // Style our checkboxes and radio buttons
 input[type="checkbox"],
 input[type="radio"] {
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-
-input[type="checkbox"] + label,
-input[type="radio"] + label {
   position: relative;
   display: inline-block;
-  padding-left: calc(24px + #{2 * $spacer--1});
+  margin: 0 $spacer--1;
   font-weight: $font--weight;
   font-size: $font--size-bump;
+  visibility: hidden;
+  width: 24px;
+  height: 24px;
+  vertical-align: middle;
 
-  &:before {
+  &::before {
     display: inline-block;
     position: absolute;
     content: "";
-    height: 24px;
-    width: 24px;
+    height: 100%;
+    width: 100%;
     border: 1px solid $color--polar-10;
     left: $spacer--1;
-    top: 50%;
-    transform: translateY(-50%);
+    top: 0;
+    left: 0;
+    visibility: visible;
   }
 
-  &:after {
+  &::after {
     display: inline-block;
     position: absolute;
     content: none;
-    height: 12px;
-    width: 12px;
-    top: 50%;
-    transform: translateY(-50%);
-    left: calc(#{$spacer--1} + 6px);
+    height: 60%;
+    width: 60%;
+    top: 20%;
+    left: 20%;
+    visibility: visible;
     background-color: $color--tiffany;
     @extend %background--tiffoam;
   }
-}
 
-input[type="radio"] + label {
-  &:before {
-    border-radius: 100%;
+  + label {
+    display: inline-block;
+    width: auto;
+    line-height: 24px;
+    vertical-align: middle;
   }
 
-  &:after {
-    border-radius: 100%;
+  &:checked::after {
+    content: "";
   }
-}
 
-input[type="checkbox"]:checked + label:after,
-input[type="radio"]:checked + label:after {
-  content: "";
-}
-
-input[type="checkbox"]:focus + label:before,
-input[type="radio"]:focus + label:before {
+  &:focus::before {
     outline: $color--polar-40 auto 3px;
+  }
+}
+
+input[type="radio"] {
+  &::before {
+    border-radius: 100%;
+  }
+
+  &::after {
+    border-radius: 100%;
+  }
 }


### PR DESCRIPTION
…riority from styling the labels to styling the actual input fields.

## Status
**READY**

## JIRA Ticket
[A link to the relevant JIRA ticket](https://wpengine.atlassian.net/browse/WEB-1842)

## Description
Fixes the popup modal select box for jeannette's experimental lead form tool from hubspot. 
This also refactors the select and radio buttons to style the inputs for checkboxes and radio buttons instead of styling the labels. 

## Impacted Areas in Application
* wpengine branded select/radio buttons.
hubspot popup modal.

## Deploy Notes

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

1. Head to https://app.hubspot.com/lead-flows/298401/details/424706 
2. Put in your test url. ie. an ngrok.io or development url branch.
3. /more/aws should have a blue modal pop up.
4. Now it's select box isn't borked.
5. Be sure to check out the speed tool and see if the radio buttons aren't borked as well.

## Random GIF
Include one random GIF to "pay" your reviewers in humor.

![Thanks for reviewing my code!](https://media.giphy.com/media/cQTrAPW7GGzkI/giphy-downsized.gif)
