### PR TITLE
Displays checkbox on Firefox (overrides styling)

### DIFF
--- a/assets/stylesheets/_forms.scss
+++ b/assets/stylesheets/_forms.scss
@@ -153,3 +153,9 @@ input[type="radio"] {
     border-radius: 100%;
   }
 }
+
+@-moz-document url-prefix() {
+  input[type="checkbox"] {
+     visibility: visible;
+  }
+}

--- a/assets/stylesheets/_forms.scss
+++ b/assets/stylesheets/_forms.scss
@@ -158,4 +158,7 @@ input[type="radio"] {
   input[type="checkbox"] {
      visibility: visible;
   }
+  input[type="radio"] {
+    visibility: visible;
+ }
 }


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
[A link to the relevant JIRA ticket](https://wpengine.atlassian.net/browse/JAN--486)

## Description
A few sentences describing the overall goals of the pull request's commits.

Overrides "visibility: hidden" on checkboxes for all Firefox browsers, so that browser checkbox will appear.

## Impacted Areas in Application
List general components of the site that this PR will affect:

* Any page with checkbox on Firefox

(GDPR, /devkit, resource center pages...)

## Deploy Notes
Notes regarding deployment the contained body of work.
If you need to change something in WordPress after deploying, make the necessary steps crystal clear.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

1. `jan-486-firefox-checkboxes`
2. get unibody updates into wpengine.local
3. View wpengine.local/devkit on firefox, checkboxes should appear
Note: This fix also support radio buttons on firefox

## Random GIF
Include one random GIF to "pay" your reviewers in humor.

![Thanks for reviewing my code!](https://media.giphy.com/media/pr3TAxmR6Vyes/giphy.gif)
