### PR TITLE
WEB-3793 Switch Open Sans fallback font to Tahoma

### DIFF
--- a/assets/stylesheets/_variables.scss
+++ b/assets/stylesheets/_variables.scss
@@ -76,7 +76,7 @@ $colors-map--grayscale: (
 $colors-map: map_merge(map_merge($colors-map--primary, $colors-map--secondary), $colors-map--grayscale);
 
 // Font settings
-$font--family:            "Open Sans", arial, sans-serif;
+$font--family:            "Open Sans", Tahoma, sans-serif;
 $font--family-heading:    $font--family;
 $font--family-code:       "Courier New", courier, "Lucida Sans Typewriter", "Lucida Typewriter", monospace;
 


### PR DESCRIPTION
## JIRA Ticket
[WEB-3793]

## Description
Switches our fallback font for Open Sans. It used to be Arial, but @hello-jason has approved Tahoma as a better visual match.

## Impacted Areas in Application

* Font family used across the Breakthrough brand

## Deploy Notes
Make sure this goes out with wpengine/wpengine-breakthrough#1111

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

1. Test with wpengine/wpengine-breakthrough#221
2. Build the theme
3. Load a page
4. See the font family declaration is `"Open Sans", Tahoma, sans-serif`

## Random GIF
Include one random GIF to "pay" your reviewers in humor.

![Thanks for reviewing my code!](https://media.giphy.com/media/IPlzKd7p0fkcw/giphy-downsized.gif)


[WEB-3793]: https://wpengine.atlassian.net/browse/WEB-3793