### PR TITLE
Add circle, update package name to @dxt/unibody

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,35 @@
+version: 2.1
+
+orbs:
+    wpengine: ryanshoover/wpengine@0.7
+
+workflows:
+    deploy:
+        jobs:
+            - wpengine/build:
+                context: DXT
+                filters:
+                    tags:
+                        only: /^\d+\.\d+\.\d+$/
+                    branches:
+                        only: /.*/
+
+            - wpengine/lint:
+                context: DXT
+                requires:
+                    - wpengine/build
+                filters:
+                    tags:
+                        only: /^\d+\.\d+\.\d+$/
+                    branches:
+                        only: /.*/
+
+            - wpengine/deploy_fury:
+                  context: DXT
+                  requires:
+                      - wpengine/lint
+                  filters:
+                      tags:
+                          only: /^\d+\.\d+\.\d+$/
+                      branches:
+                          only: /.*/

--- a/assets/stylesheets/_variables.scss
+++ b/assets/stylesheets/_variables.scss
@@ -76,7 +76,7 @@ $colors-map--grayscale: (
 $colors-map: map_merge(map_merge($colors-map--primary, $colors-map--secondary), $colors-map--grayscale);
 
 // Font settings
-$font--family:            "Open Sans", Tahoma, sans-serif;
+$font--family:            "Open Sans", tahoma, sans-serif;
 $font--family-heading:    $font--family;
 $font--family-code:       "Courier New", courier, "Lucida Sans Typewriter", "Lucida Typewriter", monospace;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@dxt/unibody",
     "version": "2.0.0",
-    "description": "The core styles for the WP Engine brand",
+    "description": "Core styles for the WP Engine brand",
     "main": "assets/javascript/",
     "style": "style.scss",
     "sass": "style.scss",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "unibody",
-    "version": "1.5.8",
+    "name": "@dxt/unibody",
+    "version": "2.0.0",
     "description": "The core styles for the WP Engine brand",
     "main": "assets/javascript/",
     "style": "style.scss",


### PR DESCRIPTION
## Description
Adds a circleci config. This doesn't yet have CI/CD set up.

Updates the package name to `@dxt/unibody` so that we can install it through Fury.

## Impacted Areas in Application
List general components of the site that this PR will affect:

* Deploy
* Installation

## Deploy Notes
Packages that use unibody need to switch their included package to `@dxt/compiler`

## Random GIF
Include one random GIF to "pay" your reviewers in humor.

![Thanks for reviewing my code!](https://media.giphy.com/media/6rJFzjeX3Aaty/giphy.gif)
